### PR TITLE
Using PropTypes from prop-types package as deprecated on main react package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "test": "mocha"
   },
   "peerDependencies": {
-    "react": "^15.x.x",
-    "prop-types": "^15.x.x"
+    "react": "^15.x.x"
   },
   "dependencies": {
-    "styletron-utils": "^2.5.1"
+    "styletron-utils": "^2.5.1",
+    "prop-types": "^15.x.x"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",
@@ -37,7 +37,6 @@
     "mocha-multi-reporters": "^1.1.3",
     "prettier": "^0.15.0",
     "react": "^15.x.x",
-    "prop-types": "^15.x.x",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
     "sinon": "^1.17.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "mocha"
   },
   "peerDependencies": {
-    "react": "^15.x.x"
+    "react": "^15.x.x",
+    "prop-types": "^15.x.x"
   },
   "dependencies": {
     "styletron-utils": "^2.5.1"
@@ -36,6 +37,7 @@
     "mocha-multi-reporters": "^1.1.3",
     "prettier": "^0.15.0",
     "react": "^15.x.x",
+    "prop-types": "^15.x.x",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
     "sinon": "^1.17.7",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { getStylesProp } from './internals';
 
 const connectStyles = (Component, styles, key = 'styles') => {
@@ -14,7 +15,7 @@ const connectStyles = (Component, styles, key = 'styles') => {
       Component.name}`;
 
   StyledElement.contextTypes = {
-    styletron: React.PropTypes.object.isRequired,
+    styletron: PropTypes.object.isRequired,
   };
 
   return StyledElement;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1016,7 +1016,7 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -1620,7 +1620,7 @@ lolex@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -1930,6 +1930,13 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.x.x:
+  version "15.5.9"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.9.tgz#d478eef0e761396942f70c78e772f76e8be747c9"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 punycode@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
I've found this package to be really useful, recently updated a project to use the latest react and noticed they have deprecated using PropTypes from the main react package. (creates error warning)

Details: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

I've simply switched over to using the prop-types package, I've run test & also made sure it works.

I've never contributed/created anything for npm, so If I've done something incorrect please let me know.

Cheers

